### PR TITLE
Add TCP connector helper

### DIFF
--- a/InModuleLib/TcpConnector.go
+++ b/InModuleLib/TcpConnector.go
@@ -1,0 +1,64 @@
+package inmodulelib
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"time"
+)
+
+const defaultTcpConnectorTimeout = 5 * time.Second
+
+// TcpConnector is a small helper for posting data to a TCP endpoint.
+type TcpConnector struct {
+	host    string
+	port    string
+	timeout time.Duration
+}
+
+// NewTcpConnector creates a TCP connector with the default timeout.
+func NewTcpConnector(host string, port string) *TcpConnector {
+	return NewTcpConnectorWithTimeout(host, port, defaultTcpConnectorTimeout)
+}
+
+// NewTcpConnectorWithTimeout creates a TCP connector with a caller-provided timeout.
+func NewTcpConnectorWithTimeout(host string, port string, timeout time.Duration) *TcpConnector {
+	return &TcpConnector{host: host, port: port, timeout: timeout}
+}
+
+// Post sends data to the configured TCP endpoint and returns the first response line.
+func (tcpConnector *TcpConnector) Post(data string) (string, error) {
+	if tcpConnector == nil {
+		return "", fmt.Errorf("tcp connector is nil")
+	}
+
+	address := net.JoinHostPort(tcpConnector.host, tcpConnector.port)
+	connection, err := net.DialTimeout("tcp", address, tcpConnector.timeout)
+	if err != nil {
+		return "", err
+	}
+	defer connection.Close()
+
+	if tcpConnector.timeout > 0 {
+		deadline := time.Now().Add(tcpConnector.timeout)
+		if err := connection.SetDeadline(deadline); err != nil {
+			return "", err
+		}
+	}
+
+	if _, err := fmt.Fprint(connection, data); err != nil {
+		return "", err
+	}
+
+	response, err := bufio.NewReader(connection).ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+
+	return response, nil
+}
+
+// PostTcp sends data to a TCP endpoint using the default connector settings.
+func PostTcp(host string, port string, data string) (string, error) {
+	return NewTcpConnector(host, port).Post(data)
+}

--- a/InModuleLib/TcpConnector_test.go
+++ b/InModuleLib/TcpConnector_test.go
@@ -1,0 +1,62 @@
+package inmodulelib
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestTcpConnectorPost(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start tcp listener: %v", err)
+	}
+	defer listener.Close()
+
+	received := make(chan string, 1)
+	serverErrors := make(chan error, 1)
+
+	go func() {
+		connection, err := listener.Accept()
+		if err != nil {
+			serverErrors <- err
+			return
+		}
+		defer connection.Close()
+
+		request, err := bufio.NewReader(connection).ReadString('\n')
+		if err != nil {
+			serverErrors <- err
+			return
+		}
+
+		received <- request
+		_, err = fmt.Fprint(connection, "posted\n")
+		serverErrors <- err
+	}()
+
+	host, port, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to split listener address: %v", err)
+	}
+
+	connector := NewTcpConnectorWithTimeout(host, port, time.Second)
+	response, err := connector.Post("hello tcp\n")
+	if err != nil {
+		t.Fatalf("failed to post tcp data: %v", err)
+	}
+
+	if response != "posted\n" {
+		t.Fatalf("expected response %q, got %q", "posted\n", response)
+	}
+
+	if request := <-received; request != "hello tcp\n" {
+		t.Fatalf("expected request %q, got %q", "hello tcp\n", request)
+	}
+
+	if err := <-serverErrors; err != nil {
+		t.Fatalf("server error: %v", err)
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide a small, reusable helper for sending data to a TCP endpoint with configurable host, port and timeout. 
- Simplify tests and callers that need to post newline-terminated payloads and read a single-line response. 

### Description
- Add `InModuleLib/TcpConnector.go` implementing `TcpConnector` with `NewTcpConnector`, `NewTcpConnectorWithTimeout`, `Post`, and convenience `PostTcp` functions. 
- `Post` dials with `net.DialTimeout`, applies a deadline if a timeout is set, writes the provided data, and returns the first newline-terminated response. 
- Add `InModuleLib/TcpConnector_test.go` which spins up a local TCP listener, verifies the sent payload is received, and asserts the returned response matches the server reply. 

### Testing
- Ran `go test ./InModuleLib`, and the new test `TestTcpConnectorPost` passed (`ok mylearnings.go/main/InModuleLib`). 
- Ran `go test ./...`, which fails due to unrelated pre-existing issues in other packages (a `fmt.Printf` formatting error in `main.go` and an existing failing test in `sandbox`), not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a34a2c2e4832883eca1cf6169ade4)